### PR TITLE
fix(search): remove duplicates

### DIFF
--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -1,7 +1,10 @@
 package core
 
 import (
+	"log/slog"
 	"testing"
+
+	"github.com/musaubrian/sik/internal/utils"
 )
 
 func TestReadMarkdown(t *testing.T) {
@@ -49,7 +52,11 @@ func TestIndex(t *testing.T) {
 	}
 
 	for _, tt := range singleOccurrenceWords {
-		if fileMeta, exists := index[tt.word]; !exists {
+		stemmedWord, err := utils.Stemm(tt.word)
+		if err != nil {
+			slog.Error(err.Error())
+		}
+		if fileMeta, exists := index[stemmedWord]; !exists {
 			t.Errorf("Expected word '%s' to be in the index", tt.word)
 		} else {
 			if pos, exists := fileMeta[tt.file]; !exists || len(pos) != 1 {
@@ -63,11 +70,15 @@ func TestIndex(t *testing.T) {
 		file string
 	}{
 		{"stuff", "../test_src/basics.md"},
-		{"featur", "../test_src/project.md"},
+		{"feature", "../test_src/project.md"},
 	}
 
 	for _, tt := range multiOccurenceWords {
-		if fileMeta, exists := index[tt.word]; !exists {
+		stemmedWord, err := utils.Stemm(tt.word)
+		if err != nil {
+			slog.Error(err.Error())
+		}
+		if fileMeta, exists := index[stemmedWord]; !exists {
 			t.Errorf("Expected word '%s' to be in the index", tt.word)
 		} else {
 			if pos, exists := fileMeta[tt.file]; !exists || len(pos) <= 1 {


### PR DESCRIPTION
- used to return all occurences/finds, and sometimes they were duplicates because of the how it appears in the word

  `helloWorld`, `helloResponse`, `hello` are 3 different occurences of the word `hello`,so it returned `<file>` *<occurences>.